### PR TITLE
Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:14.04
+
+MAINTAINER ???
+
+RUN apt-get update; apt-get install -y git mercurial golang
+
+ENV GOPATH /home/gocode
+ADD sangrenel.go /home/gocode/src/github.com/sangrenel/
+WORKDIR /home/gocode/src/github.com/sangrenel
+RUN go get
+RUN go install
+
+CMD ["-h"]
+ENTRYPOINT ["/home/gocode/bin/sangrenel"]

--- a/README.md
+++ b/README.md
@@ -56,3 +56,19 @@ GOMAXPROCS=32 / 32 workers / 3500 byte message size: ~125,000 messages/sec
 GOMAXPROCS=32 / 32 workers / 300 byte message size: ~1.38M messages/sec
 
 ![ScreenShot](http://us-east.manta.joyent.com/jalquiza/public/github/sangrenel.png)
+
+### Docker
+
+```
+$ docker run x/sangrenel
+Usage of /home/gocode/bin/sangrenel:
+  -brokers="localhost:9092": Comma delimited list of Kafka brokers
+  -noop=false: Test message generation performance, do not transmit messages
+  -rate=100000000: Apply a global message rate limit
+  -size=300: Message size in bytes
+  -topic="sangrenel": Topic to publish to
+  -workers=1: Number of Kafka client workers
+
+$ docker run x/sangrenel -brokers="localhost:9092" -workers=8
+...
+```


### PR DESCRIPTION
Here's a Dockerfile for putting sangrenel in a Docker image, along with usage instructions. The Docker container executes the sangrenel binary, passing in the specified options. Sometimes it's easier to just run a Docker container than build things. :)

This should also be easy to set up as an automated build in Docker Hub, if you're interested: http://docs.docker.com/docker-hub/builds/

sangrenel is pretty awesome, btw - thanks for creating it!
