### PR TITLE
allow messages > 1000000 bytes

### DIFF
--- a/sangrenel.go
+++ b/sangrenel.go
@@ -42,7 +42,7 @@ var (
 	// Configs.
 	brokers        []string
 	topic          string
-	msgSize        int64
+	msgSize        int
 	msgRate        int64
 	batchSize      int
 	compressionOpt string
@@ -65,7 +65,7 @@ var (
 
 func init() {
 	flag.StringVar(&topic, "topic", "sangrenel", "Topic to publish to")
-	flag.Int64Var(&msgSize, "size", 300, "Message size in bytes")
+	flag.IntVar(&msgSize, "size", 300, "Message size in bytes")
 	flag.Int64Var(&msgRate, "rate", 100000000, "Apply a global message rate limit")
 	flag.IntVar(&batchSize, "batch", 0, "Max messages per batch. Defaults to unlimited (0).")
 	flag.StringVar(&compressionOpt, "compression", "none", "Message compression: none, gzip, snappy")
@@ -185,6 +185,8 @@ func kafkaClient(n int) {
 			conf.Producer.Compression = compression
 		}
 		conf.Producer.Flush.MaxMessages = batchSize
+
+		conf.Producer.MaxMessageBytes = msgSize + 50
 
 		client, err := kafka.NewClient(brokers, conf)
 		if err != nil {


### PR DESCRIPTION
Currently the client will buck at messages over a certain size since the producer's `MaxMessageBytes` is never changed from the default. The client error is:

`kafka server: Message was too large, server rejected it to avoid allocation error.`

and originates here: https://github.com/Shopify/sarama/blob/master/async_producer.go#L252

The default is found here: https://github.com/Shopify/sarama/blob/master/config.go#L230

To reproduce, use any message size greater than the default (1000000)