### PR TITLE
fix handling default kafka version

### DIFF
--- a/sangrenel.go
+++ b/sangrenel.go
@@ -88,6 +88,7 @@ func init() {
 
 	switch Config.kafkaVersionString {
 	case "":
+		fallthrough
 	case "0.8.2.0":
 		Config.kafkaVersion = sarama.V0_8_2_0
 	case "0.8.2.1":


### PR DESCRIPTION
I'm assuming a fallthrough statement was missing as not specifying a version number would result in having version 0.0.0.0 being fed to sarama.