### PR TITLE
Support TLS for self signed certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Usage of sangrenel:
       Whether to enable TLS communcation (default "false")
   -tls-ca-cert string
       Path to the CA SSL certificate
+  -tls-cert-file string
+      Path to the certificate file
+  -tls-key-file string
+      Path to the private key file
+  -tls-insecure-skip-verify
+      TLS insecure skip verify (default false)
   -topic string
     	Kafka topic to produce to (default "sangrenel")
   -workers int


### PR DESCRIPTION
Hi @jamiealquiza. This pull request adds support for TLS with self signed certificates. In case of a self signed certificate, there will be no root ca (and thus no matching file). The new flags `-tls-cert-file` and `-tls-key-file`, together with `-tls-insecure-skip-verify`, allow for self-signed certificate usage.

Example:

```
$GOPATH/bin/sangrenel \
    -brokers=... \
    -message-batch-size=500 \
    -message-size=500 \
    -required-acks=all \
    -topic=scratch.kafka-proxy-test.dshtest \
     -tls \
     -tls-cert-file=$HOME/cert.pem \
     -tls-key-file=$HOME/key.pem \
     -tls-insecure-skip-verify
```